### PR TITLE
disallow multiple colons in locale

### DIFF
--- a/src/tests/test_public.py
+++ b/src/tests/test_public.py
@@ -57,7 +57,7 @@ class TestPublic(unittest.TestCase):
       self.assertGreater(len(data), 10)
 
     for datum in data:
-      self.assert_nonempty_string(datum.get('locale'), allow_none=False)
+      self.assert_nonempty_string(datum.get('locale'), allow_none=False, regex=re.compile(r'[\w\-&()\'\. ]*:?[\w\-&()\'\. ]*'))
       self.assert_nonempty_string(datum.get('official'), titled=False)
 
       self.assert_nonempty_string(datum.get('city'))

--- a/src/tests/test_public.py
+++ b/src/tests/test_public.py
@@ -57,6 +57,9 @@ class TestPublic(unittest.TestCase):
       self.assertGreater(len(data), 10)
 
     for datum in data:
+      # efforts to disallow '.' in locales were unsuccessful due to St., Mt., and even more unusual yet valid locale names
+      # valid locales were also found using &, (), numbers, and ' in the context of possessives
+      # the regex below limits locales to a single colon, e.g. city:county
       self.assert_nonempty_string(datum.get('locale'), allow_none=False, regex=re.compile(r'[\w\-&()\'\. ]*:?[\w\-&()\'\. ]*'))
       self.assert_nonempty_string(datum.get('official'), titled=False)
 


### PR DESCRIPTION
Had to include `-&()'.` as valid characters due to valid locales using these symbols.

Initial attempt to only allow `(St.|Mt.|[...])` didn't work because of locale `AT.& GIL. AC. GT.` in New Hampshire.